### PR TITLE
added cycle for recurring treasury proposal

### DIFF
--- a/packages/page-treasury/src/Overview/Proposal.tsx
+++ b/packages/page-treasury/src/Overview/Proposal.tsx
@@ -30,7 +30,6 @@ function ProposalDisplay ({ className = '', isMember, members, proposal: { counc
       .length,
     [council]
   );
-
   return (
     <tr className={className}>
       <td className='number'>

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -5,7 +5,7 @@ import type { BN } from '@polkadot/util';
 
 import React, { useMemo, useState } from 'react';
 
-import { Button, Input, InputAddress, InputBalance, MarkWarning, Modal, Static, TxButton } from '@polkadot/react-components';
+import { Button, Input, InputAddress, InputBalance, MarkWarning, Modal, Static, TxButton, Toggle } from '@polkadot/react-components';
 import { useApi, useToggle } from '@polkadot/react-hooks';
 import { BN_HUNDRED, BN_MILLION } from '@polkadot/util';
 
@@ -22,7 +22,8 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
   const [beneficiary, setBeneficiary] = useState<string | null>(null);
   const [isOpen, toggleOpen] = useToggle();
   const [value, setValue] = useState<BN | undefined>();
-  const [segment, setSegment] = useState<number | undefined>();
+  const [segment, setSegment] = useState<string | number | undefined>();
+  const [cycle, setCycle] = useState(false);
   const hasValue = value?.gtn(0);
 
   const bondPercentage = useMemo(
@@ -84,10 +85,23 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
                 label={t<string>('minimum bond')}
               />
               <Input
-                help={t<string>('todo: segment text')}
+                help={t<string>('duration of proposal')}
                 label={t<string>('segments')}
                 type="number"
                 onChange={setSegment}
+              />
+              {/* <Dropdown
+                help={t<string>('select cycle for this proposal')}
+                label={t<string>('cycle')}
+                options={cycleRef.current}
+                value={cycle}
+                onChange={setCycle}
+                placeholder={'choose the cycle for this proposal'}
+              /> */}
+              <Toggle
+                label={t<string>('select if this cycle, else next cycle')}
+                onChange={setCycle}
+                value={cycle}
               />
               <MarkWarning content={t<string>('Be aware that once submitted the proposal will be put to a council vote. If the proposal is rejected due to a lack of info, invalid requirements or non-benefit to the network as a whole, the full bond posted (as describe above) will be lost.')} />
             </Modal.Columns>
@@ -99,7 +113,7 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
               isDisabled={!accountId || !hasValue}
               label={t<string>('Submit proposal')}
               onStart={toggleOpen}
-              params={[value, beneficiary, segment]}
+              params={[value, beneficiary, segment, cycle]}
               tx={api.tx.treasury.proposeSpend}
             />
           </Modal.Actions>

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -53,7 +53,7 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
             <Modal.Columns hint={t<string>('The beneficiary will receive the full amount if the proposal passes.')}>
               <InputAddress
                 help={t<string>('The account to which the proposed balance will be transferred if approved')}
-                label={t<string>('beneficiary')}
+                label={t<string>('Beneficiary')}
                 onChange={setBeneficiary}
                 type='allPlus'
               />
@@ -69,12 +69,12 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
               <InputBalance
                 help={t<string>('The amount that will be allocated from the treasury pot')}
                 isError={!hasValue}
-                label={t<string>('value')}
+                label={t<string>('Value')}
                 onChange={setValue}
               />
               <Static
                 help={t<string>('The on-chain percentage for the treasury')}
-                label={t<string>('proposal bond')}
+                label={t<string>('Proposal bond')}
               >
                 {bondPercentage}
               </Static>
@@ -82,16 +82,16 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
                 defaultValue={api.consts.treasury.proposalBondMinimum.toString()}
                 help={t<string>('The minimum amount that will be bonded')}
                 isDisabled
-                label={t<string>('minimum bond')}
+                label={t<string>('Minimum bond')}
               />
               <Input
-                help={t<string>('duration of proposal')}
-                label={t<string>('segments')}
+                help={t<string>('Duration of proposal')}
+                label={t<string>('Segments')}
                 type="number"
                 onChange={setSegment}
               />
               <Toggle
-                label={t<string>('select if this cycle, else next cycle')}
+                label={t<string>('Select this or the next cycle')}
                 onChange={setCycle}
                 value={cycle}
               />

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -90,14 +90,6 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
                 type="number"
                 onChange={setSegment}
               />
-              {/* <Dropdown
-                help={t<string>('select cycle for this proposal')}
-                label={t<string>('cycle')}
-                options={cycleRef.current}
-                value={cycle}
-                onChange={setCycle}
-                placeholder={'choose the cycle for this proposal'}
-              /> */}
               <Toggle
                 label={t<string>('select if this cycle, else next cycle')}
                 onChange={setCycle}

--- a/packages/page-treasury/src/Overview/ProposalCreate.tsx
+++ b/packages/page-treasury/src/Overview/ProposalCreate.tsx
@@ -44,7 +44,7 @@ function Propose({ className }: Props): React.ReactElement<Props> | null {
             <Modal.Columns hint={t<string>('This account will make the proposal and be responsible for the bond.')}>
               <InputAddress
                 help={t<string>('Select the account you wish to submit the proposal from.')}
-                label={t<string>('submit with account')}
+                label={t<string>('Submit with account')}
                 onChange={setAccountId}
                 type='account'
                 withLabel

--- a/packages/page-treasury/src/Overview/Summary.tsx
+++ b/packages/page-treasury/src/Overview/Summary.tsx
@@ -28,7 +28,6 @@ function Summary ({ approvalCount, proposalCount }: Props): React.ReactElement<P
     () => value && value.sub(pendingBounties).sub(pendingProposals),
     [value, pendingBounties, pendingProposals]
   );
-
   return (
     <SummaryBox>
       <section>

--- a/packages/react-components/src/Input.tsx
+++ b/packages/react-components/src/Input.tsx
@@ -37,7 +37,7 @@ interface Props {
   name?: string;
   onEnter?: boolean | (() => void);
   onEscape?: () => void;
-  onChange?: (value: string) => void;
+  onChange?: (value: string | number) => void;
   onBlur?: () => void;
   onKeyDown?: (event: React.KeyboardEvent<Element>) => void;
   onKeyUp?: (event: React.KeyboardEvent<Element>) => void;

--- a/packages/react-components/src/Toggle.tsx
+++ b/packages/react-components/src/Toggle.tsx
@@ -44,7 +44,7 @@ function Toggle ({ className = '', isDisabled, isOverlay, isRadio, label, onChan
 export default React.memo(styled(Toggle)`
   > label {
     display: inline-block;
-    margin: 0 0.5rem;
+    margin: 1.5rem 2rem;
   }
 
   > label,


### PR DESCRIPTION
When users make a proposal for funding by the treasury:

⦁	they must indicate what cycle they are proposing the budget for (the current one or any cycle in the future).
⦁	they must indicate the duration of their proposal - segments (one cycle or more, these cycles must be contiguous).
⦁	Users will only be able to vote on proposals proposing in the present cycle.